### PR TITLE
Refact : 카카오 로그인

### DIFF
--- a/src/app/kakaologin/page.tsx
+++ b/src/app/kakaologin/page.tsx
@@ -1,35 +1,35 @@
 'use client';
 
 import { useMutation } from '@tanstack/react-query';
-import { useRouter } from 'next/router';
+import { useRouter, useSearchParams } from 'next/navigation';
 import React, { useEffect } from 'react';
-import { postKakaoLogin } from '../../api/kakao-login';
+import { postKakaoLogin, sendKakaoToken } from '../../api/kakao-login';
 import { useTokenCookies } from '../../hooks/useTokenCookies';
 
 const KakaoLogin = () => {
   const router = useRouter();
-  const { code } = router.query;
+  const searchParams = useSearchParams();
+  const code = searchParams.get('code');
   console.log(code);
   const { setAccessToken, setRefreshToken } = useTokenCookies();
 
-  const kakaoLogintion = useMutation((code: string | string[]) =>
+  const kakaoLoginMutation = useMutation((code: string | string[]) =>
     postKakaoLogin(code)
   );
 
   useEffect(() => {
-    if (code && !kakaoLogintion.isLoading) {
-      kakaoLogintion.mutate(code);
+    if (code && !kakaoLoginMutation.isLoading) {
+      kakaoLoginMutation.mutate(code);
     }
   }, [code]);
 
   useEffect(() => {
     const handleKakaoLoginSuccess = async () => {
-      if (kakaoLogintion.isSuccess) {
-        const kakaoAccesstoken = kakaoLogintion.data.access_token;
-        console.log(kakaoAccesstoken);
+      if (kakaoLoginMutation.isSuccess) {
+        const kakaoAccesstoken = kakaoLoginMutation.data.access_token;
 
         try {
-          const response = await kakaoAccesstoken;
+          const response = await sendKakaoToken(kakaoAccesstoken);
           const { accessToken, refreshToken } = response.response;
           setAccessToken(accessToken);
           setRefreshToken(refreshToken);
@@ -41,8 +41,8 @@ const KakaoLogin = () => {
     };
     handleKakaoLoginSuccess();
   }, [
-    kakaoLogintion.isSuccess,
-    kakaoLogintion.data,
+    kakaoLoginMutation.isSuccess,
+    kakaoLoginMutation.data,
     router,
     setAccessToken,
     setRefreshToken,

--- a/src/app/kakaologin/page.tsx
+++ b/src/app/kakaologin/page.tsx
@@ -10,7 +10,7 @@ const KakaoLogin = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
   const code = searchParams.get('code');
-  console.log(code);
+
   const { setAccessToken, setRefreshToken } = useTokenCookies();
 
   const kakaoLoginMutation = useMutation((code: string | string[]) =>

--- a/src/app/kakaosociallogin/page.tsx
+++ b/src/app/kakaosociallogin/page.tsx
@@ -2,9 +2,16 @@
 import Link from 'next/link';
 import React from 'react';
 import { kakaoAuthUrl } from '../../api/kakao-login';
+import Button from '../../components/Button';
 
 const page = () => {
-  return <Link href={kakaoAuthUrl}>카카오 로그인</Link>;
+  return (
+    <div className='flex justify-center items-center h-screen'>
+      <Link href={kakaoAuthUrl}>
+        <Button buttonSize='large'>카카오 계정으로 로그인하기</Button>
+      </Link>
+    </div>
+  );
 };
 
 export default page;

--- a/src/app/kakaosociallogin/page.tsx
+++ b/src/app/kakaosociallogin/page.tsx
@@ -1,0 +1,10 @@
+'use client';
+import Link from 'next/link';
+import React from 'react';
+import { kakaoAuthUrl } from '../../api/kakao-login';
+
+const page = () => {
+  return <Link href={kakaoAuthUrl}>카카오 로그인</Link>;
+};
+
+export default page;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,6 @@ import letterlogo from '../../public/images/momodo.svg';
 import Image from 'next/image';
 import LoginButton from '../components/LoginButton';
 import Link from 'next/link';
-import KakaoLoginButton from '../components/KakaoLoginButton';
 
 export const metadata: Metadata = {
   title: 'momodo',
@@ -19,9 +18,9 @@ export default function Home() {
         <Image src={letterlogo} alt='레터링 로고 이미지' />
       </h1>
       <div className='text-center mb-20'>
-        <KakaoLoginButton type='kakao'>
-          카카오톡 계정으로 로그인
-        </KakaoLoginButton>
+        <LoginButton type='kakao' href='/kakaosociallogin'>
+          카카오 계정으로 로그인
+        </LoginButton>
         <LoginButton type='google' href='/signup'>
           구글 계정으로 로그인
         </LoginButton>

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 interface OwnProps {
   children: string;
   onClick?(): void;
-  disabled: boolean;
+  disabled?: boolean;
   buttonSize?: 'small' | 'medium' | 'large';
 }
 


### PR DESCRIPTION
## Refact : 카카오 로그인

### 변경사항
1. 루트 페이지에서 '카카오 계정으로 로그인'버튼 클릭시 이동하는 '/kakaosociallogin' 페이지 생성
2. '/kakaosociallogin' 페이지에 버튼 컴포넌트를 사용하여 kakaoAuthUrl 연결
3. 카카오 리다이렉트 페이지인 'kakaologin' 폴더를 app 디렉토리 하위로 이동함
4. '/kakaologin' 페이지 내 로직 -> 13버젼에 맞는 함수로 코드 수정

### 안내사항
- 해당 브랜치에서 변경 내역 확인해주시면
다음 브랜치에서 'KakaoLoginButton.tsx' 컴포넌트는 제거하겠습니다 !