### PR TITLE
Feat : TodoList 기능 추가(duration: 반복주 적용, repeatDate: 반복요일) & TodoList생성시 Lists에 즉시반영

### DIFF
--- a/src/components/TodoList/TodoForm.tsx
+++ b/src/components/TodoList/TodoForm.tsx
@@ -8,6 +8,8 @@ import TodoEmoji from './TodoEmoji';
 import moment from 'moment';
 import { useMutation } from '@tanstack/react-query';
 import { postTodoData } from '../../service/todo';
+import { useQueryClient } from '@tanstack/react-query';
+// import { useMutation } from '@tanstack/react-query';
 
 interface TodoFormProps {
   type: string;
@@ -28,10 +30,12 @@ const TodoForm: React.FC<TodoFormProps> = ({ type, closeModal }) => {
   const [todoValue, setTodoValue] = useState('');
   const [todoEmoji, setTodoEmoji] = useState('🎉');
   const [repeatDays, setRepeatDays] = useState('');
-  const [duration, setDuration] = useState('');
+  const [duration, setDuration] = useState('0');
+  const queryClient = useQueryClient();
 
   // Constants
   const curretDate = moment().format('YYYY-MM-DD');
+  // const curretDate = moment().format('2023-08-01');
   const selectDayOfWeek = [
     { value: '0', name: '월요일 마다' },
     { value: '1', name: '화요일 마다' },
@@ -76,9 +80,8 @@ const TodoForm: React.FC<TodoFormProps> = ({ type, closeModal }) => {
     }
   };
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-
     const todoData: TodoData = {
       title: todoValue,
       emoji: todoEmoji,
@@ -86,24 +89,19 @@ const TodoForm: React.FC<TodoFormProps> = ({ type, closeModal }) => {
       repeatDays: repeatDays,
       duration: duration,
     };
-
-    console.log(todoData);
-    mutation.mutate(todoData);
-
-    setTodoValue('');
+    try {
+      await mutation.mutateAsync(todoData);
+      setTodoValue('');
+    } catch (error) {
+      console.log('투두 추가 에러' + error);
+    }
   };
 
-  // Mutation(추가된 TodoList 업데이트)
   const mutation = useMutation(postTodoData, {
-    onSuccess(data) {
-      console.log(data);
-    },
-    onError(error) {
-      console.error(error);
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['todolist'] });
     },
   });
-
-  console.log(repeatDays);
 
   return (
     <article>
@@ -165,7 +163,6 @@ const TodoForm: React.FC<TodoFormProps> = ({ type, closeModal }) => {
               onChange={handleDuration}
               value={duration}
             >
-              {/* <option value='안 함'>안 함</option> */}
               {selectWeek.map((day) => (
                 <option key={day.value} value={day.value}>
                   {day.name}

--- a/src/components/TodoList/TodoForm.tsx
+++ b/src/components/TodoList/TodoForm.tsx
@@ -28,12 +28,6 @@ const TodoForm: React.FC<TodoFormProps> = ({ type, closeModal }) => {
   const [todoValue, setTodoValue] = useState('');
   const [todoEmoji, setTodoEmoji] = useState('🎉');
   const [repeatDays, setRepeatDays] = useState('');
-  // const [todoData, setTodoData] = useState<TodoData>({
-  //   title: '',
-  //   emoji: '',
-  //   dueDate: curretDate,
-  //   repeatDays: '',
-  // });
 
   const selectWeek = [
     { value: '0', name: '일요일 마다' },
@@ -44,14 +38,24 @@ const TodoForm: React.FC<TodoFormProps> = ({ type, closeModal }) => {
     { value: '5', name: '금요일 마다' },
     { value: '6', name: '토요일 마다' },
   ];
+  const daysOfWeek = ['일', '월', '화', '수', '목', '금', '토'];
 
-  // 98~103 line에서 onChange error 발생해서 임의로 변경하였음. 수정필요
   const handleTodoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setTodoValue(e.target.value);
   };
 
   const handleRepeatDay = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    setRepeatDays(e.target.value);
+    const selectedValue = e.target.value;
+    if (selectedValue === '안 함') {
+      setRepeatDays('');
+    } else if (repeatDays.includes(selectedValue)) {
+      const updatedDays = repeatDays.replace(selectedValue, '');
+      setRepeatDays(updatedDays);
+    } else if (repeatDays !== '') {
+      setRepeatDays((prevRepeatDays) => prevRepeatDays + selectedValue);
+    } else {
+      setRepeatDays(selectedValue);
+    }
   };
 
   const mutation = useMutation(postTodoData, {
@@ -70,8 +74,8 @@ const TodoForm: React.FC<TodoFormProps> = ({ type, closeModal }) => {
       title: todoValue,
       emoji: todoEmoji,
       dueDate: curretDate,
-      repeatDays: '0',
-      duration: '0',
+      repeatDays: repeatDays,
+      duration: '14',
     };
 
     console.log(todoData);
@@ -107,6 +111,7 @@ const TodoForm: React.FC<TodoFormProps> = ({ type, closeModal }) => {
           <select
             className='bg-grey-65 rounded-lg pl-28 pr-3 py-2 text-right text-xs'
             onChange={handleRepeatDay}
+            value={repeatDays}
           >
             <option value='안 함'>안 함</option>
             {selectWeek.map((day) => (
@@ -115,6 +120,14 @@ const TodoForm: React.FC<TodoFormProps> = ({ type, closeModal }) => {
               </option>
             ))}
           </select>
+          {repeatDays !== '' && (
+            <div className='ml-2 text-xs'>
+              {repeatDays
+                .split('')
+                .map((value: any) => daysOfWeek[value])
+                .join(', ')}
+            </div>
+          )}
         </div>
         {type === 'newtodo' ? (
           <Button disabled={todoValue.length === 0}>추가하기</Button>

--- a/src/components/TodoList/TodoForm.tsx
+++ b/src/components/TodoList/TodoForm.tsx
@@ -23,12 +23,14 @@ export interface TodoData {
 }
 
 const TodoForm: React.FC<TodoFormProps> = ({ type, closeModal }) => {
+  // State
   //TODO: 실제 유저가 선택한 날짜와 연결해주기
-  const curretDate = moment().format('YYYY-MM-DD');
   const [todoValue, setTodoValue] = useState('');
   const [todoEmoji, setTodoEmoji] = useState('🎉');
   const [repeatDays, setRepeatDays] = useState('');
 
+  // Constants
+  const curretDate = moment().format('YYYY-MM-DD');
   const selectWeek = [
     { value: '0', name: '일요일 마다' },
     { value: '1', name: '월요일 마다' },
@@ -39,7 +41,8 @@ const TodoForm: React.FC<TodoFormProps> = ({ type, closeModal }) => {
     { value: '6', name: '토요일 마다' },
   ];
   const daysOfWeek = ['일', '월', '화', '수', '목', '금', '토'];
-
+  
+  // Event Handlers
   const handleTodoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setTodoValue(e.target.value);
   };
@@ -58,15 +61,6 @@ const TodoForm: React.FC<TodoFormProps> = ({ type, closeModal }) => {
     }
   };
 
-  const mutation = useMutation(postTodoData, {
-    onSuccess(data) {
-      console.log(data);
-    },
-    onError(error) {
-      console.error(error);
-    },
-  });
-
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
@@ -83,6 +77,16 @@ const TodoForm: React.FC<TodoFormProps> = ({ type, closeModal }) => {
 
     setTodoValue('');
   };
+  
+  // Mutation(추가된 TodoList 업데이트)
+  const mutation = useMutation(postTodoData, {
+    onSuccess(data) {
+      console.log(data);
+    },
+    onError(error) {
+      console.error(error);
+    },
+  });
 
   return (
     <article>
@@ -98,6 +102,7 @@ const TodoForm: React.FC<TodoFormProps> = ({ type, closeModal }) => {
         </button>
       </div>
       <TodoEmoji setTodoEmoji={setTodoEmoji} />
+      {/* TodoList 입력  */}
       <form className='flex flex-col items-center' onSubmit={handleSubmit}>
         <input
           type='text'
@@ -106,6 +111,7 @@ const TodoForm: React.FC<TodoFormProps> = ({ type, closeModal }) => {
           value={todoValue}
           onChange={handleTodoChange}
         />
+        {/* 반복요일 선택 */}
         <div className='flex items-center mb-10'>
           <p className='text-xs bg-grey-65 px-3 py-2 rounded-lg mr-2'>반 복</p>
           <select
@@ -129,6 +135,7 @@ const TodoForm: React.FC<TodoFormProps> = ({ type, closeModal }) => {
             </div>
           )}
         </div>
+        {/* type 따른 Button 모음 */}
         {type === 'newtodo' ? (
           <Button disabled={todoValue.length === 0}>추가하기</Button>
         ) : (

--- a/src/components/TodoList/TodoForm.tsx
+++ b/src/components/TodoList/TodoForm.tsx
@@ -28,20 +28,28 @@ const TodoForm: React.FC<TodoFormProps> = ({ type, closeModal }) => {
   const [todoValue, setTodoValue] = useState('');
   const [todoEmoji, setTodoEmoji] = useState('🎉');
   const [repeatDays, setRepeatDays] = useState('');
+  const [duration, setDuration] = useState('');
 
   // Constants
   const curretDate = moment().format('YYYY-MM-DD');
-  const selectWeek = [
-    { value: '0', name: '일요일 마다' },
-    { value: '1', name: '월요일 마다' },
-    { value: '2', name: '화요일 마다' },
-    { value: '3', name: '수요일 마다' },
-    { value: '4', name: '목요일 마다' },
-    { value: '5', name: '금요일 마다' },
-    { value: '6', name: '토요일 마다' },
+  const selectDayOfWeek = [
+    { value: '0', name: '월요일 마다' },
+    { value: '1', name: '화요일 마다' },
+    { value: '2', name: '수요일 마다' },
+    { value: '3', name: '목요일 마다' },
+    { value: '4', name: '금요일 마다' },
+    { value: '5', name: '토요일 마다' },
+    { value: '6', name: '일요일 마다' },
   ];
-  const daysOfWeek = ['일', '월', '화', '수', '목', '금', '토'];
-  
+  const selectWeek = [
+    { value: '0', name: '안 함' },
+    { value: '7', name: '1주' },
+    { value: '14', name: '2주' },
+    { value: '21', name: '3주' },
+    { value: '28', name: '4주' },
+  ];
+  const daysOfWeek = ['월', '화', '수', '목', '금', '토', '일'];
+
   // Event Handlers
   const handleTodoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setTodoValue(e.target.value);
@@ -49,15 +57,22 @@ const TodoForm: React.FC<TodoFormProps> = ({ type, closeModal }) => {
 
   const handleRepeatDay = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const selectedValue = e.target.value;
+
     if (selectedValue === '안 함') {
       setRepeatDays('');
     } else if (repeatDays.includes(selectedValue)) {
       const updatedDays = repeatDays.replace(selectedValue, '');
       setRepeatDays(updatedDays);
-    } else if (repeatDays !== '') {
-      setRepeatDays((prevRepeatDays) => prevRepeatDays + selectedValue);
     } else {
-      setRepeatDays(selectedValue);
+      setRepeatDays((prevRepeatDays) => prevRepeatDays + selectedValue);
+    }
+  };
+  const handleDuration = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const selectedValue = e.target.value;
+    if (selectedValue === '안 함') {
+      setDuration('');
+    } else {
+      setDuration(selectedValue);
     }
   };
 
@@ -69,7 +84,7 @@ const TodoForm: React.FC<TodoFormProps> = ({ type, closeModal }) => {
       emoji: todoEmoji,
       dueDate: curretDate,
       repeatDays: repeatDays,
-      duration: '14',
+      duration: duration,
     };
 
     console.log(todoData);
@@ -77,7 +92,7 @@ const TodoForm: React.FC<TodoFormProps> = ({ type, closeModal }) => {
 
     setTodoValue('');
   };
-  
+
   // Mutation(추가된 TodoList 업데이트)
   const mutation = useMutation(postTodoData, {
     onSuccess(data) {
@@ -87,6 +102,8 @@ const TodoForm: React.FC<TodoFormProps> = ({ type, closeModal }) => {
       console.error(error);
     },
   });
+
+  console.log(repeatDays);
 
   return (
     <article>
@@ -112,29 +129,52 @@ const TodoForm: React.FC<TodoFormProps> = ({ type, closeModal }) => {
           onChange={handleTodoChange}
         />
         {/* 반복요일 선택 */}
-        <div className='flex items-center mb-10'>
-          <p className='text-xs bg-grey-65 px-3 py-2 rounded-lg mr-2'>반 복</p>
-          <select
-            className='bg-grey-65 rounded-lg pl-28 pr-3 py-2 text-right text-xs'
-            onChange={handleRepeatDay}
-            value={repeatDays}
-          >
-            <option value='안 함'>안 함</option>
-            {selectWeek.map((day) => (
-              <option key={day.value} value={day.value}>
-                {day.name}
-              </option>
-            ))}
-          </select>
-          {repeatDays !== '' && (
-            <div className='ml-2 text-xs'>
-              {repeatDays
-                .split('')
-                .map((value: any) => daysOfWeek[value])
-                .join(', ')}
-            </div>
-          )}
+        <div className='flex flex-col gap-3 mb-10'>
+          <div className='flex items-center'>
+            <p className='text-xs bg-grey-65 px-3 py-2 rounded-lg mr-2'>
+              반복 요일
+            </p>
+            <select
+              className='bg-grey-65 rounded-lg pl-28 pr-3 py-2 text-right text-xs'
+              onChange={handleRepeatDay}
+              value={repeatDays}
+            >
+              <option value='안 함'>안 함</option>
+              {selectDayOfWeek.map((day) => (
+                <option key={day.value} value={day.value}>
+                  {day.name}
+                </option>
+              ))}
+            </select>
+            {repeatDays !== '' && (
+              <div className='ml-2 text-xs'>
+                {repeatDays
+                  .split('')
+                  .map((value: any) => daysOfWeek[value])
+                  .join(', ')}
+              </div>
+            )}
+            {/* 반복주간 선택 */}
+          </div>
+          <div className='flex items-center'>
+            <p className='text-xs bg-grey-65 px-3 py-2 rounded-lg mr-2'>
+              반복 주간
+            </p>
+            <select
+              className='bg-grey-65 rounded-lg pl-28 pr-3 py-2 text-right text-xs'
+              onChange={handleDuration}
+              value={duration}
+            >
+              {/* <option value='안 함'>안 함</option> */}
+              {selectWeek.map((day) => (
+                <option key={day.value} value={day.value}>
+                  {day.name}
+                </option>
+              ))}
+            </select>
+          </div>
         </div>
+
         {/* type 따른 Button 모음 */}
         {type === 'newtodo' ? (
           <Button disabled={todoValue.length === 0}>추가하기</Button>


### PR DESCRIPTION
# Feat : TodoList 기능 추가(duration: 반복 주 적용, repeatDate: 반복요일) & Todolist생성시 Lists에 즉시반영

## 변경사항
- TodoList 생성 시 반복요일(repeatDate) 선택 UI 구현
- TodoList 생성 시 반욕주간(duration)선택 UI 구현
<img width="350" alt="image" src="https://github.com/momodo-ToDoSupport/momodo_front/assets/89332492/d8d5972e-26a7-4841-ba72-36c2562cb943">

- TodoList 추가 시 MutateAsync 적용하여 getTodolist data 동기화 구현 


## 안내사항
- 반복요일(repeatDate) 중복 선택 시, 해당요일 삭제됨.
- 선택한 반복요일을 명시적으로 보여줄 수 있도록 UI 구현하였음.
- 반복주간(duration)은 7일 단위로 1~4주 선택 가능하도록 항목을 구현하였음.
- 반복주간(duration) 의 초깃값으로 '선택 안함'을 지정하였음.
- Todolist를 추가할 경우 이전 API 통신을 통해 가져온 Todolist data를 보여지기 때문에, react-Qurty MutateAsync 메서드를 활용하여 동기화 시켰음.
- Modal 컴포넌트에서 작성된 event handler 와 새롭게 생성되는 함수가 많이 최적화가 필요함.(ex. useCallback) 
- 반복되는 함수나 비슷한 로직을 Custom Hook으로 생성하여 분리하고 관리 필요함.